### PR TITLE
Add correct signal handling for node application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,17 @@
 FROM node:latest
 
+# grab tini for signal processing and zombie killing
+ENV TINI_VERSION v0.9.0
+RUN set -x \
+	&& wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini" \
+	&& wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini.asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
+	&& gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
+	&& rm -r "$GNUPGHOME" /usr/local/bin/tini.asc \
+	&& chmod +x /usr/local/bin/tini \
+	&& tini -h
+
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
@@ -7,4 +19,7 @@ COPY package.json /usr/src/app/
 RUN npm install --silent
 COPY . /usr/src/app
 COPY prod.env /usr/src/app/.env
-CMD [ "npm", "start" ]
+COPY docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["npm","start"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+set -- tini -- "$@"
+
+exec "$@"


### PR DESCRIPTION
Node applications in Docker do not recognise Signals. This PR fixes this by using tini (https://github.com/krallin/tini). It allows stopping a container with STRG+C when having it started with `docker run` (without detaching).